### PR TITLE
replace the rust syntax highlighter in ace for an alan one

### DIFF
--- a/theme/playground_editor/mode-rust.js
+++ b/theme/playground_editor/mode-rust.js
@@ -1,0 +1,303 @@
+ace.define("ace/mode/rust_highlight_rules",["require","exports","module","ace/lib/oop","ace/mode/text_highlight_rules"], function(require, exports, module) {
+"use strict";
+
+var oop = require("../lib/oop");
+var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+
+var RustHighlightRules = function() {
+
+    this.$rules = {
+        start: [{
+            include: "#keywords"
+        }, {
+            include: "#doubleQuoteStrings"
+        }, {
+            include: "#singleQuoteStrings"
+        }, {
+            include: "#comment"
+        }, {
+            include: "#importKeywords"
+        }, {
+            include: "#booleans"
+        }, {
+            include: "#numbers"
+        }, {
+            include: "#operators"
+        }, {
+            include: "#symbols"
+        }],
+        "#comment": [{
+            token: "punctuation.definition.comment",
+            regex: /\/\*\*(?!\/)/,
+            push: [{
+                token: "punctuation.definition.comment",
+                regex: /\*\//,
+                next: "pop"
+            }, {
+                defaultToken: "comment.block.documentation"
+            }]
+        }, {
+            token: [
+                "punctuation.definition.comment",
+                "comment.block",
+                "punctuation.decorator.internaldeclaration",
+                "storage.type.internaldeclaration"
+            ],
+            regex: /(\/\*)(?:(\s*)(@)(internal)(?=\s|\*\/))?/,
+            push: [{
+                token: "punctuation.definition.comment",
+                regex: /\*\//,
+                next: "pop"
+            }, {
+                defaultToken: "comment.block"
+            }]
+        }, {
+            token: [
+                "punctuation.whitespace.comment.leading",
+                "punctuation.definition.comment",
+                "comment.line.double-slash",
+                "punctuation.decorator.internaldeclaration",
+                "storage.type.internaldeclaration"
+            ],
+            regex: /((?:^[ \t]+)?)(\/\/)(?:(\s*)(@)(internal)(?=\s|$))?/,
+            push: [{
+                token: "text",
+                regex: /(?=$)/,
+                next: "pop"
+            }, {
+                defaultToken: "comment.line.double-slash"
+            }]
+        }],
+        "#keywords": [{
+            token: "keyword.control",
+            regex: /\b(?:type|event|fn|on|return|const|let|emit|prefix|infix|precedence|if|else|new|interface)\b/
+        }],
+        "#importKeywords": [{
+            token: "variable.language",
+            regex: /\b(?:import|export|as|from)\b/
+        }],
+        "#numbers": [{
+            token: "string.other",
+            regex: /\b(?:0(?:x|X)[0-9a-fA-F]*|(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:(?:e|E)(?:\+|-)?[0-9]+)?)(?:L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\b/
+        }],
+        "#symbols": [{
+            token: "constant.numeric",
+            regex: /[,\{\}\(\)<>\[\]\.=@:]/
+        }],
+        "#operators": [{
+            token: "constant.numeric",
+            regex: /[+\-\/*^.~`!@#$%&|:;<?=][+\-\/*^.~`!@#$%&|:;<>?=]*/
+        }],
+        "#booleans": [{
+            token: "string.other",
+            regex: /\b(?:true|false)\b/
+        }],
+        "#doubleQuoteStrings": [{
+            token: "string.quoted.double",
+            regex: /"/,
+            push: [{
+                token: "string.quoted.double",
+                regex: /"/,
+                next: "pop"
+            }, {
+                token: "constant.character.escape",
+                regex: /\\./
+            }, {
+                defaultToken: "string.quoted.double"
+            }]
+        }],
+        "#singleQuoteStrings": [{
+            token: "string.quoted.single",
+            regex: /'/,
+            push: [{
+                token: "string.quoted.single",
+                regex: /'/,
+                next: "pop"
+            }, {
+                defaultToken: "string.quoted.single"
+            }]
+        }]
+    }
+    
+    this.normalizeRules();
+};
+
+RustHighlightRules.metaData = {
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    name: "Rust",
+    scopeName: "source.ln"
+}
+
+
+oop.inherits(RustHighlightRules, TextHighlightRules);
+
+exports.RustHighlightRules = RustHighlightRules;
+});
+
+ace.define("ace/mode/folding/cstyle",["require","exports","module","ace/lib/oop","ace/range","ace/mode/folding/fold_mode"], function(require, exports, module) {
+"use strict";
+
+var oop = require("../../lib/oop");
+var Range = require("../../range").Range;
+var BaseFoldMode = require("./fold_mode").FoldMode;
+
+var FoldMode = exports.FoldMode = function(commentRegex) {
+    if (commentRegex) {
+        this.foldingStartMarker = new RegExp(
+            this.foldingStartMarker.source.replace(/\|[^|]*?$/, "|" + commentRegex.start)
+        );
+        this.foldingStopMarker = new RegExp(
+            this.foldingStopMarker.source.replace(/\|[^|]*?$/, "|" + commentRegex.end)
+        );
+    }
+};
+oop.inherits(FoldMode, BaseFoldMode);
+
+(function() {
+    
+    this.foldingStartMarker = /([\{\[\(])[^\}\]\)]*$|^\s*(\/\*)/;
+    this.foldingStopMarker = /^[^\[\{\(]*([\}\]\)])|^[\s\*]*(\*\/)/;
+    this.singleLineBlockCommentRe= /^\s*(\/\*).*\*\/\s*$/;
+    this.tripleStarBlockCommentRe = /^\s*(\/\*\*\*).*\*\/\s*$/;
+    this.startRegionRe = /^\s*(\/\*|\/\/)#?region\b/;
+    this._getFoldWidgetBase = this.getFoldWidget;
+    this.getFoldWidget = function(session, foldStyle, row) {
+        var line = session.getLine(row);
+    
+        if (this.singleLineBlockCommentRe.test(line)) {
+            if (!this.startRegionRe.test(line) && !this.tripleStarBlockCommentRe.test(line))
+                return "";
+        }
+    
+        var fw = this._getFoldWidgetBase(session, foldStyle, row);
+    
+        if (!fw && this.startRegionRe.test(line))
+            return "start"; // lineCommentRegionStart
+    
+        return fw;
+    };
+
+    this.getFoldWidgetRange = function(session, foldStyle, row, forceMultiline) {
+        var line = session.getLine(row);
+        
+        if (this.startRegionRe.test(line))
+            return this.getCommentRegionBlock(session, line, row);
+        
+        var match = line.match(this.foldingStartMarker);
+        if (match) {
+            var i = match.index;
+
+            if (match[1])
+                return this.openingBracketBlock(session, match[1], row, i);
+                
+            var range = session.getCommentFoldRange(row, i + match[0].length, 1);
+            
+            if (range && !range.isMultiLine()) {
+                if (forceMultiline) {
+                    range = this.getSectionRange(session, row);
+                } else if (foldStyle != "all")
+                    range = null;
+            }
+            
+            return range;
+        }
+
+        if (foldStyle === "markbegin")
+            return;
+
+        var match = line.match(this.foldingStopMarker);
+        if (match) {
+            var i = match.index + match[0].length;
+
+            if (match[1])
+                return this.closingBracketBlock(session, match[1], row, i);
+
+            return session.getCommentFoldRange(row, i, -1);
+        }
+    };
+    
+    this.getSectionRange = function(session, row) {
+        var line = session.getLine(row);
+        var startIndent = line.search(/\S/);
+        var startRow = row;
+        var startColumn = line.length;
+        row = row + 1;
+        var endRow = row;
+        var maxRow = session.getLength();
+        while (++row < maxRow) {
+            line = session.getLine(row);
+            var indent = line.search(/\S/);
+            if (indent === -1)
+                continue;
+            if  (startIndent > indent)
+                break;
+            var subRange = this.getFoldWidgetRange(session, "all", row);
+            
+            if (subRange) {
+                if (subRange.start.row <= startRow) {
+                    break;
+                } else if (subRange.isMultiLine()) {
+                    row = subRange.end.row;
+                } else if (startIndent == indent) {
+                    break;
+                }
+            }
+            endRow = row;
+        }
+        
+        return new Range(startRow, startColumn, endRow, session.getLine(endRow).length);
+    };
+    this.getCommentRegionBlock = function(session, line, row) {
+        var startColumn = line.search(/\s*$/);
+        var maxRow = session.getLength();
+        var startRow = row;
+        
+        var re = /^\s*(?:\/\*|\/\/|--)#?(end)?region\b/;
+        var depth = 1;
+        while (++row < maxRow) {
+            line = session.getLine(row);
+            var m = re.exec(line);
+            if (!m) continue;
+            if (m[1]) depth--;
+            else depth++;
+
+            if (!depth) break;
+        }
+
+        var endRow = row;
+        if (endRow > startRow) {
+            return new Range(startRow, startColumn, endRow, line.length);
+        }
+    };
+
+}).call(FoldMode.prototype);
+
+});
+
+ace.define("ace/mode/rust",["require","exports","module","ace/lib/oop","ace/mode/text","ace/mode/rust_highlight_rules","ace/mode/folding/cstyle"], function(require, exports, module) {
+"use strict";
+
+var oop = require("../lib/oop");
+var TextMode = require("./text").Mode;
+var RustHighlightRules = require("./rust_highlight_rules").RustHighlightRules;
+var FoldMode = require("./folding/cstyle").FoldMode;
+
+var Mode = function() {
+    this.HighlightRules = RustHighlightRules;
+    this.foldingRules = new FoldMode();
+};
+oop.inherits(Mode, TextMode);
+
+(function() {
+    this.$id = "ace/mode/rust"
+}).call(Mode.prototype);
+
+exports.Mode = Mode;
+});                (function() {
+                    window.require(["ace/mode/rust"], function(m) {
+                        if (typeof module == "object" && typeof exports == "object" && module) {
+                            module.exports = m;
+                        }
+                    });
+                })();
+            


### PR DESCRIPTION
Solves part of https://github.com/alantech/alan/issues/221. Replace the [mdbook Rust mode for ace](https://github.com/rust-lang/mdBook/blob/master/src/theme/playground_editor/mode-rust.js) with one for Alan mode generated from following the instructions on the [tmlanguage tool section](https://ace.c9.io/#nav=higlighter) for this [tmlanguage file](https://github.com/alantech/vscode-alan/blob/main/syntaxes/alan.tmLanguage.json).